### PR TITLE
Fix popups bg color

### DIFF
--- a/wikipedia-dark.css
+++ b/wikipedia-dark.css
@@ -816,4 +816,9 @@
   {
     color: #777 !important;
   }
+  
+  div.navpopup
+  {
+    background-color: #333;
+  }
 }


### PR DESCRIPTION
Popups are a power feature of Wikipedia. This fixes the bg color to be dark so the text becomes readable.