### PR TITLE
Added styling for `.hll`

### DIFF
--- a/wikipedia-dark.css
+++ b/wikipedia-dark.css
@@ -916,6 +916,10 @@
         -webkit-filter: invert(100%);
     }
 
+    .hll {
+        background-color: #383838 !important;
+    }
+
     /* Preferences */
 
     .client-js #preferences {

--- a/wikipedia-dark.css
+++ b/wikipedia-dark.css
@@ -917,7 +917,7 @@
     }
 
     .hll {
-        background-color: #383838 !important;
+        background-color: #2B2B2B !important;
     }
 
     /* Preferences */


### PR DESCRIPTION
Original:

![screenshot](https://user-images.githubusercontent.com/10424281/38458967-c74d8186-3a9b-11e8-8754-c3228bf5a168.png)

I've changed it to:

![screenshot](https://user-images.githubusercontent.com/10424281/38459073-196a908e-3a9d-11e8-93ee-9b1e0721fffa.png)

(the page used for screenshot example was the [D article](https://en.wikipedia.org/wiki/D_(programming_language)#Example_1))

Also IDK much about what kind of style rules you want for this so I just changed it to what I think looks nice, but if you have some sort of consistency rules you're free to set the colour yourself. I just changed it so it wasn't that weird yellow.