### PR TITLE
Added #bbb background-color to images

### DIFF
--- a/wikipedia-dark.user.css
+++ b/wikipedia-dark.user.css
@@ -1155,6 +1155,10 @@
         opacity: 0.85 !important;
     }
 
+    .image img {
+        background-color: #bbb !important;
+    }
+
     .globegris {
         background: transparent !important;
     }


### PR DESCRIPTION
added light background-color (#bbb) to images to make ones with transparent backgrounds and dark text/content much more easy to see