### PR TITLE
Use translucent low alpha white for TOC background

### DIFF
--- a/wikipedia-dark.user.css
+++ b/wikipedia-dark.user.css
@@ -1475,6 +1475,15 @@
     .mwe-popups-overlay {
         background-color: rgba(0, 0, 0, 0.6) !important;
     }
+    
+    /* TOC */
+    .vector-toc-pinned #vector-toc-pinned-container .vector-toc::after {
+        display: none
+    }
+
+    .vector-toc {
+        background-color: #ffffff10;
+    }
 
     /* Minor fixes */
 


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/8212504/219076829-6e4882c3-53bb-49b3-835d-a6600bfdb114.png)
After:
![image](https://user-images.githubusercontent.com/8212504/219076939-8ce9ffae-954a-4aef-8f0d-ba81465e3fb4.png)
