### PR TITLE
Add support for spanish wikipedia

### DIFF
--- a/wikipedia-dark.user.css
+++ b/wikipedia-dark.user.css
@@ -1867,6 +1867,26 @@
     }
 }
 
+@-moz-document domain("es.wikipedia.org"), domain("es.m.wikipedia.org"){
+    /* Spanish Version */
+        .main-top {
+            background-color: #333 !important;
+            border: 1px solid #555 !important;
+        }
+        .main-box{
+            background-color: #333 !important;
+            border: 1px solid #555 !important;
+        }
+        
+        .main-top-left {
+            background-image: linear-gradient(to right, #222, #222, transparent) !important;
+        }
+        
+        .main-top-articleCount {
+            background-image: linear-gradient(to left, #333, #333, transparent, transparent) !important;
+        }
+}
+
 @-moz-document domain("commons.wikimedia.org"), domain("wiktionary.org"), domain("wikibooks.org"), domain("wikinews.org"), domain("wikisource.org"), domain("wikivoyage.org") {
     /* Wikimedia Commons super quick fixes */
 


### PR DESCRIPTION
Simply edited the front page. It's literally the same as russian so I copy and pasted their css code.

Another way is to just include spanish into russian section, but if the spanish version differs from the russian it would be a pain in the ass to maintain.

[es.wikipedia.org](es.wikipedia.org)

